### PR TITLE
Make Tree type abstract, add views

### DIFF
--- a/docs/Data/Tree.md
+++ b/docs/Data/Tree.md
@@ -4,8 +4,9 @@
 
 ``` purescript
 data Tree a
-  = Tree a (Array (Tree a))
 ```
+
+An abstract tree type
 
 ##### Instances
 ``` purescript
@@ -19,6 +20,50 @@ instance monadTree :: Monad Tree
 instance foldableTree :: Foldable Tree
 instance traversableTree :: Traversable Tree
 ```
+
+#### `View`
+
+``` purescript
+data View f a
+  = View a (Array (f a))
+```
+
+A view which is used to construct and destruct the tree. This type is a
+pattern functor/signature, where `f` represents the recursive structure.
+
+#### `out`
+
+``` purescript
+out :: forall a. Tree a -> View Tree a
+```
+
+Pattern match on a tree. Example:
+
+````purescript
+case out t of
+  View a ts -> ...
+````
+
+#### `into`
+
+``` purescript
+into :: forall a. View Tree a -> Tree a
+```
+
+Construct a tree from a tree pattern/view. Example:
+
+````purescript
+tree :: Tree Int
+tree = into $ View 0 []
+````
+
+#### `transView`
+
+``` purescript
+transView :: forall f g a. (forall a. f a -> g a) -> View f a -> View g a
+```
+
+Map a tree across a natural transformation. Example:
 
 #### `flatten`
 

--- a/docs/Data/Tree.md
+++ b/docs/Data/Tree.md
@@ -60,7 +60,7 @@ tree = into $ View 0 []
 #### `transView`
 
 ``` purescript
-transView :: forall f g a. (forall a. f a -> g a) -> View f a -> View g a
+transView :: forall f g a. (forall b. f b -> g b) -> View f a -> View g a
 ```
 
 Map a tree across a natural transformation.

--- a/docs/Data/Tree.md
+++ b/docs/Data/Tree.md
@@ -63,7 +63,7 @@ tree = into $ View 0 []
 transView :: forall f g a. (forall a. f a -> g a) -> View f a -> View g a
 ```
 
-Map a tree across a natural transformation. Example:
+Map a tree across a natural transformation.
 
 #### `flatten`
 

--- a/src/Data/Tree.purs
+++ b/src/Data/Tree.purs
@@ -1,5 +1,9 @@
 module Data.Tree
-  ( Tree(..)
+  ( Tree()
+  , View(..)
+  , out
+  , into
+  , transView
   , flatten
   ) where
 
@@ -9,7 +13,34 @@ import Data.Foldable (Foldable, foldr, foldl, foldMap)
 import Data.Traversable (Traversable, traverse, sequence)
 import Data.NonEmpty (NonEmpty(), (:|))
 
+-- | An abstract tree type
 data Tree a = Tree a (Array (Tree a))
+
+-- | A view which is used to construct and destruct the tree. This type is a
+-- | pattern functor/signature, where `f` represents the recursive structure.
+data View f a = View a (Array (f a))
+
+-- | Pattern match on a tree. Example:
+-- |
+-- | ````purescript
+-- | case out t of
+-- |   View a ts -> ...
+-- | ````
+out :: forall a. Tree a -> View Tree a
+out (Tree a ts) = View a ts
+
+-- | Construct a tree from a tree pattern/view. Example:
+-- |
+-- | ````purescript
+-- | tree :: Tree Int
+-- | tree = into $ View 0 []
+-- | ````
+into :: forall a. View Tree a -> Tree a
+into (View a ts) = Tree a ts
+
+-- | Map a tree across a natural transformation.
+transView :: forall f g a. (forall a. f a -> g a) -> View f a -> View g a
+transView η (View a ts) = View a (η <$> ts)
 
 instance showTree :: (Show a) => Show (Tree a) where
   show (Tree a ts) = "Tree " <> show a <> " " <> show ts

--- a/src/Data/Tree.purs
+++ b/src/Data/Tree.purs
@@ -39,7 +39,7 @@ into :: forall a. View Tree a -> Tree a
 into (View a ts) = Tree a ts
 
 -- | Map a tree across a natural transformation.
-transView :: forall f g a. (forall a. f a -> g a) -> View f a -> View g a
+transView :: forall f g a. (forall b. f b -> g b) -> View f a -> View g a
 transView η (View a ts) = View a (η <$> ts)
 
 instance showTree :: (Show a) => Show (Tree a) where


### PR DESCRIPTION
Resolves #2.

This is an example of how to do it; it's not imperative that this be merged immediately, but I thought I would put it up as a proof of concept. The approach of using a pattern functor is pretty standard in ML, as well as in certain regional dialects of Haskell... I have found in practice after using this technique quite extensively that it balances out the (usually) competing requirements of modularity and ease of use pretty nicely.

One of the nice things about this is that we could provide multiple view types (for instance, one that used lists and one that used arrays, or something even more elaborate). We can change the underlying tree representation at will, and only incur the cost of conversion at a single layer of structure in the view.

Also, feel free to bikeshed on names (including `View`, `into`, `out`, and `transView`). Another option might be to call it a `Pattern`... I don't personally have any preference.
